### PR TITLE
Fix external executable path bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ conda env create -n spanseq --file data/envs/spanseqenv.yml
 conda activate spanseq
 
 pip3 install -e .
+
+# On recent version of python/pip it might be required to add these additional flags
+pip3 install --no-build-isolation --config-settings editable_mode=compat -e .
 ```
 ### Install SpanSeq from Anaconda
 
@@ -147,7 +150,7 @@ Distance Arguments:
   -d {jaccard,szymkiewicz_simpson,cosine,kmer_inv,mash,identity}, --distanceMethod {jaccard,szymkiewicz_simpson,cosine,kmer_inv,mash,identity}
                         Method for calculating the distance between sequences by ggsearch (identity), mash (mash) or kma (the rest)
   -hd HOBOHM1_DISTANCE, --hobohm1_distance HOBOHM1_DISTANCE
-                        Distance used for hobom1 algorithm to reduce the amount of sequence to be used for distance calculation.Only for --mode 'hobohm_reduce' and 'hobohm_split'. For
+                        Distance used for hobom1 algorithm to reduce the amount of sequence to be used for distance calculation.Only for --approach 'hobohm_reduce' and 'hobohm_split'. For
                         example, if the value is 0.6, sequences with 0.6 identical to another sequences will not be considered for distance calculation.
   -hm {kma,cdhit}, --hobohm1_method {kma,cdhit}
                         Software to be used for the Hobohm1 algorithm.

--- a/src/spanseq/utils/configuration.py
+++ b/src/spanseq/utils/configuration.py
@@ -352,8 +352,8 @@ class Config(dict):
                 if os.path.isfile(path):
                     dir_path = os.path.dirname(path)
                 else:
-                    dir_path = path + "/"
-                configfile["software"][method]["path"] = dir_path
+                    dir_path = path
+                configfile["software"][method]["path"] = dir_path + "/"
             else:
                 sys.exit("The folder {} does not exists".format(path))
         else:
@@ -362,10 +362,10 @@ class Config(dict):
                     if os.path.isfile(path):
                         dir_path = os.path.dirname(path)
                     else:
-                        dir_path = path + "/"
-                    configfile["software"][method]["path"] = dir_path
+                        dir_path = path
+                    configfile["software"][method]["path"] = dir_path + "/"
                 else:
-                    sys.exit("The folder {} does not exists".format(dir_path))
+                    sys.exit("The folder {} does not exists".format(path))
             else:
                 sp_folder = os.path.dirname(os.path.dirname(
                                                 os.path.realpath(__file__)))

--- a/src/spanseq/utils/environment_mixin.py
+++ b/src/spanseq/utils/environment_mixin.py
@@ -62,7 +62,7 @@ class Environment:
         if os.path.split(conda_env)[1] not in Environment.standard_names:
             sys.exit(("SpanSeq requires that the conda environment activated"
                 " is spanseq-light (spanseqenv_light.yml) or spanseq "
-                "(spanseq.yml) not {os.path.split(conda_env)[1]}"))
+                "(spanseq.yml) not {}".format(os.path.split(conda_env)[1])))
         else:
             return conda_env
 

--- a/src/spanseq/workflow/rules/dbscan.smk
+++ b/src/spanseq/workflow/rules/dbscan.smk
@@ -1,4 +1,3 @@
-## TODO: Add -H option
 rule ccphylo_dbscan:
     input:
         output_dist = "tmp/{sample}.phy"
@@ -10,12 +9,12 @@ rule ccphylo_dbscan:
         "benchmarks/{sample}.dbscan.benchmark.txt"
     params:
         dist_value = config["clustering"]["dist_value"],
-        memory_disk = config["software"]["dbscan"]["memory_disk"],
+        mem_flag = "-H" if config["software"]["dbscan"]["memory_disk"] else "",
         temp_files = config["general"]["tmpdir"],
         ccphylo_path = config["software"]["dbscan"]["path"]
     log:
         "log/{sample}_dbscan.log"
     shell:
         "{params.ccphylo_path}ccphylo dbscan -i {input.output_dist} " \
-        "-e {params.dist_value}  -p "\
+        "-e {params.dist_value} {params.mem_flag} -p " \
         "-T {params.temp_files} -o {output.output_dbscan}"


### PR DESCRIPTION
This fixes the bug I run into when specifying the the `-CP` flag (see details below).

In the `snakemake` rules, the path was wrongly resolved to `/opt/homebrew/anaconda3/envs/spanseq_ccphylo/binccphylo`, missing a `/` before the executable name.

@ffalfred 

---

Other fixes:

- Fixed a minor typo in a python string.
- Implemented the `-H` option for `ccphylo dbscan` command
- Added a README fix. Closes #5 (if you do not plan to change the install setup)

---

<details>

<summary>Detailed error (click to expand)</summary>

```bash
[25-06-24 12:35:31] $ spanseq split -c 0.25 -i Enhancers_sequences.fa -s nucleotides -o ./spanseq_output -k 17 -m 15 -n 10 -f merged_table -d mash -l 1000 -a hobohm_split -hd 0.90 -H -b 5 -CP "/opt/homebrew/anaconda3/envs/spanseq_ccphylo/bin/ccphylo"
/opt/homebrew/anaconda3/envs/spanseq/lib/python3.10/site-packages/snakemake/utils.py:471: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
Building DAG of jobs...
Using shell: /bin/bash
Provided cores: 10
Rules claiming more threads will be scaled down.
Job stats:
job                 count    min threads    max threads
----------------  -------  -------------  -------------
all                     1              1              1
ccphylo_dbscan          1             10             10
ccphylo_makespan        1             10             10
mash_dist               1             10             10
merged_df               1              1              1
total                   5              1             10

Select jobs to execute...

[Tue Jun 24 12:35:48 2025]
rule mash_dist:
    input: /Volumes/Famafia/brain-magnet/Enhancers_sequences.fa
    output: tmp/Enhancers_sequences.phy
    log: log/Enhancers_sequences_mash.log
    jobid: 3
    benchmark: benchmarks/Enhancers_sequences.mash.benchmark.txt
    reason: Missing output files: tmp/Enhancers_sequences.phy
    wildcards: sample=Enhancers_sequences
    threads: 10
    resources: tmpdir=/var/folders/lk/6tlpjm1j2333b_7k0mdwgy7w0000gn/T


        bioseq=("nucleotides")
        if [ "$bioseq" = "nucleotides" ]
        then
            mash triangle -i /Volumes/Famafia/brain-magnet/Enhancers_sequences.fa             -k 17 -s 1024 -i              -p 10  > tmp/Enhancers_sequences.phy             
        else
            mash triangle -i /Volumes/Famafia/brain-magnet/Enhancers_sequences.fa             -k 17 -s 1024 -i -a             -p 10  > tmp/Enhancers_sequences.phy             
        fi
        
Your conda installation is not configured to use strict channel priorities. This is however crucial for having robust and correct environments (for details, see https://conda-forge.org/docs/user/tipsandtricks.html). Please consider to configure strict priorities by executing 'conda config --set channel_priority strict'.
Max p-value: 1
[Tue Jun 24 16:08:02 2025]
Finished job 3.
1 of 5 steps (20%) done
Select jobs to execute...

[Tue Jun 24 16:08:02 2025]
rule ccphylo_dbscan:
    input: tmp/Enhancers_sequences.phy
    output: Enhancers_sequences_clusters.tsv
    log: log/Enhancers_sequences_dbscan.log
    jobid: 2
    benchmark: benchmarks/Enhancers_sequences.dbscan.benchmark.txt
    reason: Missing output files: Enhancers_sequences_clusters.tsv; Input files updated by another job: tmp/Enhancers_sequences.phy
    wildcards: sample=Enhancers_sequences
    threads: 10
    resources: tmpdir=/var/folders/lk/6tlpjm1j2333b_7k0mdwgy7w0000gn/T

/opt/homebrew/anaconda3/envs/spanseq_ccphylo/binccphylo dbscan -i tmp/Enhancers_sequences.phy -e 0.25  -p -T /Volumes/Famafia/brain-magnet/spanseq_output/tmp/ -o Enhancers_sequences_clusters.tsv
/bin/bash: /opt/homebrew/anaconda3/envs/spanseq_ccphylo/binccphylo: No such file or directory
[Tue Jun 24 16:08:02 2025]
Error in rule ccphylo_dbscan:
    jobid: 2
    output: Enhancers_sequences_clusters.tsv
    log: log/Enhancers_sequences_dbscan.log (check log file(s) for error message)
    shell:
        /opt/homebrew/anaconda3/envs/spanseq_ccphylo/binccphylo dbscan -i tmp/Enhancers_sequences.phy -e 0.25  -p -T /Volumes/Famafia/brain-magnet/spanseq_output/tmp/ -o Enhancers_sequences_clusters.tsv
        (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)

Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
Complete log: .snakemake/log/2025-06-24T123532.821744.snakemake.log
Command 'snakemake --use-conda -p -c1 --snakefile /Users/victor/Documents/ProjectsDev/genomics/SpanSeq/src/spanseq/workflow/Snakefile --configfile ./spanseq_output/config/config_spanseq.yaml --conda-frontend mamba --conda-prefix /Users/victor/Documents/ProjectsDev/genomics/SpanSeq/src/spanseq/../../data/envs/ --stats /Volumes/Famafia/brain-magnet/spanseq_output/log/snakemake.stats --directory ./spanseq_output --cores 10' returned non-zero exit status 1.
```
</details>